### PR TITLE
환자방문 수정 기능 구현 

### DIFF
--- a/src/main/java/com/dev/patientpractice/controller/PatientController.java
+++ b/src/main/java/com/dev/patientpractice/controller/PatientController.java
@@ -1,7 +1,7 @@
 package com.dev.patientpractice.controller;
 
-import com.dev.patientpractice.dto.request.PatientModificationRequest;
-import com.dev.patientpractice.dto.request.PatientRegistrationRequest;
+import com.dev.patientpractice.dto.request.patient.PatientModificationRequest;
+import com.dev.patientpractice.dto.request.patient.PatientRegistrationRequest;
 import com.dev.patientpractice.dto.response.Response;
 import com.dev.patientpractice.service.PatientService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/dev/patientpractice/controller/VisitController.java
+++ b/src/main/java/com/dev/patientpractice/controller/VisitController.java
@@ -1,6 +1,7 @@
 package com.dev.patientpractice.controller;
 
-import com.dev.patientpractice.dto.request.VisitCreationRequest;
+import com.dev.patientpractice.dto.request.visit.VisitCreationRequest;
+import com.dev.patientpractice.dto.request.visit.VisitModificationRequest;
 import com.dev.patientpractice.dto.response.Response;
 import com.dev.patientpractice.service.VisitService;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,13 @@ public class VisitController {
     @PostMapping
     public Response createVisit(@RequestBody @Valid VisitCreationRequest body) {
         visitService.createVisit(body);
+        return Response.success(null);
+    }
+
+    @PatchMapping("/{visitId}")
+    public Response updateVisit(@PathVariable Long visitId,
+                                @RequestBody @Valid VisitModificationRequest body) {
+        visitService.updateVisit(visitId, body);
         return Response.success(null);
     }
 

--- a/src/main/java/com/dev/patientpractice/dto/request/patient/PatientModificationRequest.java
+++ b/src/main/java/com/dev/patientpractice/dto/request/patient/PatientModificationRequest.java
@@ -1,4 +1,4 @@
-package com.dev.patientpractice.dto.request;
+package com.dev.patientpractice.dto.request.patient;
 
 import lombok.Getter;
 

--- a/src/main/java/com/dev/patientpractice/dto/request/patient/PatientRegistrationRequest.java
+++ b/src/main/java/com/dev/patientpractice/dto/request/patient/PatientRegistrationRequest.java
@@ -1,4 +1,4 @@
-package com.dev.patientpractice.dto.request;
+package com.dev.patientpractice.dto.request.patient;
 
 import com.dev.patientpractice.entity.Hospital;
 import com.dev.patientpractice.entity.Patient;

--- a/src/main/java/com/dev/patientpractice/dto/request/visit/VisitCreationRequest.java
+++ b/src/main/java/com/dev/patientpractice/dto/request/visit/VisitCreationRequest.java
@@ -1,4 +1,4 @@
-package com.dev.patientpractice.dto.request;
+package com.dev.patientpractice.dto.request.visit;
 
 
 import com.dev.patientpractice.entity.Hospital;

--- a/src/main/java/com/dev/patientpractice/dto/request/visit/VisitModificationRequest.java
+++ b/src/main/java/com/dev/patientpractice/dto/request/visit/VisitModificationRequest.java
@@ -1,0 +1,13 @@
+package com.dev.patientpractice.dto.request.visit;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class VisitModificationRequest {
+    private LocalDateTime receivedAt;  // 접수일시
+    private String visitStatusCode;  // 방문상태코드
+}

--- a/src/main/java/com/dev/patientpractice/entity/Patient.java
+++ b/src/main/java/com/dev/patientpractice/entity/Patient.java
@@ -1,6 +1,6 @@
 package com.dev.patientpractice.entity;
 
-import com.dev.patientpractice.dto.request.PatientModificationRequest;
+import com.dev.patientpractice.dto.request.patient.PatientModificationRequest;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/dev/patientpractice/entity/Visit.java
+++ b/src/main/java/com/dev/patientpractice/entity/Visit.java
@@ -1,12 +1,15 @@
 package com.dev.patientpractice.entity;
 
+import com.dev.patientpractice.dto.request.visit.VisitModificationRequest;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -44,5 +47,15 @@ public class Visit extends BaseEntity {
      */
     public void delete() {
         this.visitStatusCode = "3";
+    }
+
+    public void update(VisitModificationRequest visit) {
+        if (Objects.nonNull(visit.getReceivedAt())) {
+            this.receivedAt = visit.getReceivedAt();
+        }
+
+        if (StringUtils.hasText(visit.getVisitStatusCode())) {
+            this.visitStatusCode = visit.getVisitStatusCode();
+        }
     }
 }

--- a/src/main/java/com/dev/patientpractice/service/PatientService.java
+++ b/src/main/java/com/dev/patientpractice/service/PatientService.java
@@ -1,7 +1,7 @@
 package com.dev.patientpractice.service;
 
-import com.dev.patientpractice.dto.request.PatientModificationRequest;
-import com.dev.patientpractice.dto.request.PatientRegistrationRequest;
+import com.dev.patientpractice.dto.request.patient.PatientModificationRequest;
+import com.dev.patientpractice.dto.request.patient.PatientRegistrationRequest;
 import com.dev.patientpractice.entity.Hospital;
 import com.dev.patientpractice.entity.Patient;
 import com.dev.patientpractice.exception.ErrorCode;

--- a/src/main/java/com/dev/patientpractice/service/VisitService.java
+++ b/src/main/java/com/dev/patientpractice/service/VisitService.java
@@ -1,6 +1,6 @@
 package com.dev.patientpractice.service;
 
-import com.dev.patientpractice.dto.request.VisitCreationRequest;
+import com.dev.patientpractice.dto.request.visit.VisitCreationRequest;
 import com.dev.patientpractice.entity.Hospital;
 import com.dev.patientpractice.entity.Patient;
 import com.dev.patientpractice.entity.Visit;


### PR DESCRIPTION
- 병원과 환자가 변경될 일은 없기 때문에 접수일시와 방문상태코드만 변경할 수 있도록 기능 구현
- 동시에 수정을 할 경우보다 각각 수정이 일어날 경우가 많아 HTTP METHOD 를 PATCH 로 설정하여 구현
- request data 중 방문상태코드가 존재하는 코드인지 확인
- 환자방문내역이 존재하지 않을 경우 exception 처리

issue : #17