### PR TITLE
런타임 시 병원, 코드그룹, 코드 테이블 초기 데이터 설정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,9 +14,16 @@ spring:
       hibernate:
         format_sql: true
         use_sql_comments: true
+    defer-datasource-initialization: true
+
   h2:
     console:
       enabled: true
       path: /h2-console
       settings:
         web-allow-others: true
+  sql:
+    init:
+      mode: always
+      continue-on-error: true
+      data-locations: classpath:sql/data.sql

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -1,0 +1,24 @@
+INSERT INTO Hospital (created_at, name, care_facility_number, director_name, deleted)
+VALUES
+    (CURRENT_TIMESTAMP(),'사랑병원', '230620-23db3b2f995b', '김병원장', false),
+    (CURRENT_TIMESTAMP(),'더큰마음병원', '230620-1d1f637d4d70', '이병원장', false),
+    (CURRENT_TIMESTAMP(),'코미코병원', '230620-7848f80f1d40', '박병원장', false);
+
+INSERT INTO CODE_GROUP (code_group, name, description)
+VALUES
+    ('성별코드', '성별코드', '성별을 표시'),
+    ('방문상태코드', '방문상태코드', '환자방문의 상태'),
+    ('진료과목코드', '진료과목코드', '진료과목'),
+    ('진료유형코드', '진료유형코드', '진료의 유형');
+
+INSERT INTO CODE (code_group, code, name)
+VALUES
+    ('성별코드', 'M', '남'),
+    ('성별코드', 'F', '여'),
+    ('방문상태코드', '1', '방문중'),
+    ('방문상태코드', '2', '종료'),
+    ('방문상태코드', '3', '취소'),
+    ('진료과목코드', '01', '내과'),
+    ('진료과목코드', '02', '안과'),
+    ('진료유형코드', 'D', '약처방'),
+    ('진료유형코드', 'T', '검사');


### PR DESCRIPTION
- 병원, 코드그룹, 코드에 기본적인 데이터 저장(data.sql 참고)
- application.yml 설정
1. jpa.defer-datasource-initialization: true -> script 파일이 hibernate 초기화 이후 동작하게 하기 위한 옵션
2. sql.init.mode: always -> 서버 시작시 항상 classpath의 sql문을 실행하도록 설정
3. sql.init.continue-on-error: false -> 애플리케이션을 시작하는 동안 SQL 오류를 무시하도록 설정(SQL 오류가 발생하더라도 애플리케이션이 계속 시작된다.)
4. sql.init.data-locations: classpath:sql/data.sql -> 서버 시작시 dml sql 문을 실행할 위치 및 파일 지정 (resources/sql/data.sql 실행된다.)

issue : #19