### PR TITLE
환자별 환자방문 목록조회 기능 구현

### DIFF
--- a/src/main/java/com/dev/patientpractice/controller/VisitController.java
+++ b/src/main/java/com/dev/patientpractice/controller/VisitController.java
@@ -5,6 +5,8 @@ import com.dev.patientpractice.dto.request.visit.VisitModificationRequest;
 import com.dev.patientpractice.dto.response.Response;
 import com.dev.patientpractice.service.VisitService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -20,6 +22,12 @@ public class VisitController {
     public Response createVisit(@RequestBody @Valid VisitCreationRequest body) {
         visitService.createVisit(body);
         return Response.success(null);
+    }
+
+    @GetMapping("/patients/{patientId}")
+    public Response getVisits(@PathVariable Long patientId,
+                              @PageableDefault(page = 1) Pageable pageable) {
+        return Response.success(visitService.getVisits(patientId, pageable));
     }
 
     @PatchMapping("/{visitId}")

--- a/src/main/java/com/dev/patientpractice/dto/response/visit/VisitResponse.java
+++ b/src/main/java/com/dev/patientpractice/dto/response/visit/VisitResponse.java
@@ -1,0 +1,29 @@
+package com.dev.patientpractice.dto.response.visit;
+
+import com.dev.patientpractice.entity.Visit;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class VisitResponse {
+    private Long id;  // 환자방문ID
+    private Long hospitalId;  // 병원ID
+    private Long patientId;  // 환자ID
+    private LocalDateTime receivedAt;  // 접수일시
+    private String visitStatusCode;  // 방문상태코드
+
+    public static VisitResponse from(Visit visit) {
+        return VisitResponse.builder()
+                .id(visit.getId())
+                .hospitalId(visit.getHospital().getId())
+                .patientId(visit.getPatient().getId())
+                .receivedAt(visit.getReceivedAt())
+                .visitStatusCode(visit.getVisitStatusCode())
+                .build();
+    }
+}

--- a/src/main/java/com/dev/patientpractice/repository/VisitRepository.java
+++ b/src/main/java/com/dev/patientpractice/repository/VisitRepository.java
@@ -1,7 +1,11 @@
 package com.dev.patientpractice.repository;
 
 import com.dev.patientpractice.entity.Visit;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VisitRepository extends JpaRepository<Visit, Long> {
+
+    Page<Visit> findAllByPatient_Id(Long patientId, Pageable pageable);
 }


### PR DESCRIPTION
- 환자ID를 기준으로 환자방문 목록을 조회해온다.
- 페이징 처리 적용(페이지 시작번호: 1, 기본 size : 10, 정렬: id 역순)
    - 환자 목록 조회의 페이지 번호가 1부터 시작하기 때문에 일관성을 위해 페이지 시작을 1로 설정
- 환자방문 이력이 조회되지 않으면 exception 처리

issue : #21