### PR TITLE
fix : 환자 정보 등록, 수정 시 성별코드가 코드테이블에 존재하는지 확인

### DIFF
--- a/src/main/java/com/dev/patientpractice/service/PatientService.java
+++ b/src/main/java/com/dev/patientpractice/service/PatientService.java
@@ -19,34 +19,39 @@ import java.time.ZoneId;
 @RequiredArgsConstructor
 public class PatientService {
 
+    public static final String GENDER_CODE = "성별코드";
     private final HospitalRepository hospitalRepository;
     private final PatientRepository patientRepository;
+    private final CodeService codeService;
 
     @Transactional
     public void generatePatient(PatientRegistrationRequest body) {
-        String patientNumber = generatePatientRegistrationNumber();
+        codeService.checkCode(GENDER_CODE, body.getGenderCode());
 
         Hospital hospital = hospitalRepository.findByIdAndDeleted(body.getHospitalId(), false)
                 .orElseThrow(() -> new PatientApplicationException(ErrorCode.HOSPITAL_NOT_FOUND, String.format("병원 ID: %s", body.getHospitalId())));
 
+        String patientNumber = generatePatientRegistrationNumber();
         Patient patient = body.toEntity(hospital, patientNumber);
         patientRepository.save(patient);
     }
 
     public String generatePatientRegistrationNumber() {
         int currentYear = LocalDateTime.now(ZoneId.of("Asia/Seoul")).getYear();
-        int yearlySerialNumber = GetSerialNumbersByYear(currentYear);
+        int yearlySerialNumber = getSerialNumbersByYear(currentYear);
         String formattedSerialNumber = String.format("%06d", yearlySerialNumber);
         return currentYear + formattedSerialNumber;
     }
 
-    private int GetSerialNumbersByYear(int currentYear) {
+    private int getSerialNumbersByYear(int currentYear) {
         int sequentialNumber = patientRepository.countByCreatedAtYear(currentYear);
         return sequentialNumber + 1;
     }
 
     @Transactional
     public void updatePatient(Long patientId, PatientModificationRequest body) {
+        codeService.checkCode(GENDER_CODE, body.getGenderCode());
+
         Patient patient = patientRepository.findByIdAndDeleted(patientId, false)
                 .orElseThrow(() -> new PatientApplicationException(ErrorCode.PATIENT_NOT_FOUND, String.format("환자 ID: %s", patientId)));
         patient.update(body);


### PR DESCRIPTION
- 코드테이블에 존재하는 성별코드만 사용해야되기에 요청 성별코드 데이터 확인하는 로직 추가
- 메소드명 오타 수정

issue : #23