### PR TITLE
환자 목록 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,14 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.12'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.dev'
@@ -20,8 +27,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // querydsl
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
 
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -30,3 +42,24 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+// querydsl
+def querydslDir = "$buildDir/generated/querydsl"
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+

--- a/src/main/java/com/dev/patientpractice/config/QueryDslConfig.java
+++ b/src/main/java/com/dev/patientpractice/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.dev.patientpractice.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/dev/patientpractice/controller/PatientController.java
+++ b/src/main/java/com/dev/patientpractice/controller/PatientController.java
@@ -24,11 +24,8 @@ public class PatientController {
     }
 
     @GetMapping
-    public Response getPatients(@RequestParam(defaultValue = "1") int pageNo,
-                                @RequestParam(defaultValue = "10") int pageSize,
-                                PatientsInquiryRequest params) {
-        // TODO pageSize, pageNo를 params 안에 넣어 같이 사용해야되는가?
-        return Response.success(patientService.getPatients(pageNo, pageSize, params));
+    public Response getPatients(@Valid PatientsInquiryRequest params) {
+        return Response.success(patientService.getPatients(params));
     }
 
     @GetMapping("/{patientId}")

--- a/src/main/java/com/dev/patientpractice/controller/PatientController.java
+++ b/src/main/java/com/dev/patientpractice/controller/PatientController.java
@@ -2,6 +2,7 @@ package com.dev.patientpractice.controller;
 
 import com.dev.patientpractice.dto.request.patient.PatientModificationRequest;
 import com.dev.patientpractice.dto.request.patient.PatientRegistrationRequest;
+import com.dev.patientpractice.dto.request.patient.PatientsInquiryRequest;
 import com.dev.patientpractice.dto.response.Response;
 import com.dev.patientpractice.service.PatientService;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,14 @@ public class PatientController {
     public Response generatePatient(@RequestBody @Valid PatientRegistrationRequest body) {
         patientService.generatePatient(body);
         return Response.success(null);
+    }
+
+    @GetMapping
+    public Response getPatients(@RequestParam(defaultValue = "1") int pageNo,
+                                @RequestParam(defaultValue = "10") int pageSize,
+                                PatientsInquiryRequest params) {
+        // TODO pageSize, pageNo를 params 안에 넣어 같이 사용해야되는가?
+        return Response.success(patientService.getPatients(pageNo, pageSize, params));
     }
 
     @GetMapping("/{patientId}")

--- a/src/main/java/com/dev/patientpractice/dto/request/patient/PatientInquiry.java
+++ b/src/main/java/com/dev/patientpractice/dto/request/patient/PatientInquiry.java
@@ -1,0 +1,28 @@
+package com.dev.patientpractice.dto.request.patient;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor
+public class PatientInquiry {
+    private String name;  // 환자명
+    private String registrationNumber;  // 환자등록번호
+    private String genderCode;  // 성별
+    private String birthDate;  // 생년월일
+    private String phoneNumber;  // 휴대전화번호
+    private LocalDate latestVisit;  // 최근방문
+
+    public PatientInquiry(String name, String registrationNumber, String genderCode, String birthDate, String phoneNumber, LocalDateTime latestVisit) {
+        this.name = name;
+        this.registrationNumber = registrationNumber;
+        this.genderCode = genderCode;
+        this.birthDate = birthDate;
+        this.phoneNumber = phoneNumber;
+        this.latestVisit = Objects.nonNull(latestVisit) ? latestVisit.toLocalDate() : null;
+    }
+}

--- a/src/main/java/com/dev/patientpractice/dto/request/patient/PatientsInquiryRequest.java
+++ b/src/main/java/com/dev/patientpractice/dto/request/patient/PatientsInquiryRequest.java
@@ -1,6 +1,7 @@
 package com.dev.patientpractice.dto.request.patient;
 
 import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -14,5 +15,6 @@ public class PatientsInquiryRequest {
     private Long hospitalId;  // 병원 ID
     private String name;  // 환자명
     private String registrationNumber;  // 환자등록번호
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate birthDate;  // 생년월일
 }

--- a/src/main/java/com/dev/patientpractice/dto/request/patient/PatientsInquiryRequest.java
+++ b/src/main/java/com/dev/patientpractice/dto/request/patient/PatientsInquiryRequest.java
@@ -1,13 +1,17 @@
 package com.dev.patientpractice.dto.request.patient;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.Data;
 
+import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 
-@Getter
-@NoArgsConstructor
+@Data
 public class PatientsInquiryRequest {
+    private int pageNo = 1;  // 페이지 번호
+    private int pageSize = 10;  // 페이지 사이즈
+
+    @NotNull(message = "필수값 hospitalId 값이 없습니다.")
+    private Long hospitalId;  // 병원 ID
     private String name;  // 환자명
     private String registrationNumber;  // 환자등록번호
     private LocalDate birthDate;  // 생년월일

--- a/src/main/java/com/dev/patientpractice/dto/request/patient/PatientsInquiryRequest.java
+++ b/src/main/java/com/dev/patientpractice/dto/request/patient/PatientsInquiryRequest.java
@@ -1,0 +1,14 @@
+package com.dev.patientpractice.dto.request.patient;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class PatientsInquiryRequest {
+    private String name;  // 환자명
+    private String registrationNumber;  // 환자등록번호
+    private LocalDate birthDate;  // 생년월일
+}

--- a/src/main/java/com/dev/patientpractice/dto/response/PageResponse.java
+++ b/src/main/java/com/dev/patientpractice/dto/response/PageResponse.java
@@ -1,0 +1,28 @@
+package com.dev.patientpractice.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Pageable;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PageResponse {
+    private int page;  // 현재 페이지
+    private int size;  // 현재 페이지에서 보이는 데이터 수
+    private int totalPages;  // 전체 페이지 수
+    private int totalCount;  // 전체 데이터 수
+
+    public static PageResponse of(Pageable pageable, long totalCount) {
+        return PageResponse.builder()
+                .page(pageable.getPageNumber() + 1)
+                .size(pageable.getPageSize())
+                .totalPages((int) Math.ceil((double) totalCount / pageable.getPageSize()))
+                .totalCount((int) totalCount)
+                .build();
+
+    }
+}

--- a/src/main/java/com/dev/patientpractice/dto/response/patient/PatientInquiryResponse.java
+++ b/src/main/java/com/dev/patientpractice/dto/response/patient/PatientInquiryResponse.java
@@ -24,6 +24,7 @@ public class PatientInquiryResponse {
     private String birthDate;  // 생년월일
     private String phoneNumber;  // 휴대전화번호
     private HospitalResponse hospital;  // 병원
+    @Builder.Default
     private List<VisitResponse> visits = new ArrayList<>();  // 환자방문
 
     public static PatientInquiryResponse from(Patient patient) {

--- a/src/main/java/com/dev/patientpractice/dto/response/patient/PatientsInquiryResponse.java
+++ b/src/main/java/com/dev/patientpractice/dto/response/patient/PatientsInquiryResponse.java
@@ -1,28 +1,23 @@
 package com.dev.patientpractice.dto.response.patient;
 
-import lombok.Data;
+import com.dev.patientpractice.dto.request.patient.PatientInquiry;
+import com.dev.patientpractice.dto.response.PageResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Pageable;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.Objects;
+import java.util.List;
 
-@Data
+@Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class PatientsInquiryResponse {
-    private String name;  // 환자명
-    private String registrationNumber;  // 환자등록번호
-    private String genderCode;  // 성별
-    private String birthDate;  // 생년월일
-    private String phoneNumber;  // 휴대전화번호
-    private LocalDate latestVisit;  // 최근방문
 
-    public PatientsInquiryResponse(String name, String registrationNumber, String genderCode, String birthDate, String phoneNumber, LocalDateTime latestVisit) {
-        this.name = name;
-        this.registrationNumber = registrationNumber;
-        this.genderCode = genderCode;
-        this.birthDate = birthDate;
-        this.phoneNumber = phoneNumber;
-        this.latestVisit = Objects.nonNull(latestVisit) ? latestVisit.toLocalDate() : null;
+    private List<PatientInquiry> patients;  // 환자 데이터
+    private PageResponse page;  // 페이지 데이터
+
+    public static PatientsInquiryResponse of(List<PatientInquiry> patients, Pageable pageable, long totalCount) {
+        return new PatientsInquiryResponse(patients, PageResponse.of(pageable, totalCount));
     }
 }

--- a/src/main/java/com/dev/patientpractice/dto/response/patient/PatientsInquiryResponse.java
+++ b/src/main/java/com/dev/patientpractice/dto/response/patient/PatientsInquiryResponse.java
@@ -1,0 +1,28 @@
+package com.dev.patientpractice.dto.response.patient;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Data
+@NoArgsConstructor
+public class PatientsInquiryResponse {
+    private String name;  // 환자명
+    private String registrationNumber;  // 환자등록번호
+    private String genderCode;  // 성별
+    private String birthDate;  // 생년월일
+    private String phoneNumber;  // 휴대전화번호
+    private LocalDate latestVisit;  // 최근방문
+
+    public PatientsInquiryResponse(String name, String registrationNumber, String genderCode, String birthDate, String phoneNumber, LocalDateTime latestVisit) {
+        this.name = name;
+        this.registrationNumber = registrationNumber;
+        this.genderCode = genderCode;
+        this.birthDate = birthDate;
+        this.phoneNumber = phoneNumber;
+        this.latestVisit = Objects.nonNull(latestVisit) ? latestVisit.toLocalDate() : null;
+    }
+}

--- a/src/main/java/com/dev/patientpractice/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/dev/patientpractice/exception/GlobalControllerAdvice.java
@@ -4,6 +4,7 @@ import com.dev.patientpractice.dto.response.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -21,6 +22,12 @@ public class GlobalControllerAdvice {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     private ResponseEntity<?> handleMethodArgumentValidException(MethodArgumentNotValidException e) {
+        return ResponseEntity.status(ErrorCode.INVALID_PARAMETER.getHttpStatus())
+                .body(Response.error(ErrorCode.INVALID_PARAMETER.name(), e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
+    }
+
+    @ExceptionHandler(BindException.class)
+    private ResponseEntity<?> handleBeanPropertyBindingResultException(BindException e) {
         return ResponseEntity.status(ErrorCode.INVALID_PARAMETER.getHttpStatus())
                 .body(Response.error(ErrorCode.INVALID_PARAMETER.name(), e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
     }

--- a/src/main/java/com/dev/patientpractice/exception/PatientApplicationException.java
+++ b/src/main/java/com/dev/patientpractice/exception/PatientApplicationException.java
@@ -10,6 +10,10 @@ public class PatientApplicationException extends RuntimeException {
     private ErrorCode errorCode;
     private String message;
 
+    public PatientApplicationException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
     @Override
     public String getMessage() {
         if (message == null) {

--- a/src/main/java/com/dev/patientpractice/repository/PatientRepository.java
+++ b/src/main/java/com/dev/patientpractice/repository/PatientRepository.java
@@ -1,12 +1,13 @@
 package com.dev.patientpractice.repository;
 
 import com.dev.patientpractice.entity.Patient;
+import com.dev.patientpractice.repository.querydsl.PatientRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
-public interface PatientRepository extends JpaRepository<Patient, Long> {
+public interface PatientRepository extends JpaRepository<Patient, Long>, PatientRepositoryCustom {
 
     @Query("SELECT COUNT(p) FROM Patient p WHERE YEAR(p.createdAt) = :year")
     int countByCreatedAtYear(int year);

--- a/src/main/java/com/dev/patientpractice/repository/querydsl/PatientRepositoryCustom.java
+++ b/src/main/java/com/dev/patientpractice/repository/querydsl/PatientRepositoryCustom.java
@@ -3,9 +3,7 @@ package com.dev.patientpractice.repository.querydsl;
 import com.dev.patientpractice.dto.request.patient.PatientsInquiryRequest;
 import com.dev.patientpractice.dto.response.patient.PatientsInquiryResponse;
 
-import java.util.List;
-
 public interface PatientRepositoryCustom {
 
-    List<PatientsInquiryResponse> findAllByConditions(int pageNo, int pageSize, PatientsInquiryRequest params);
+    PatientsInquiryResponse findAllByConditions(int pageNo, int pageSize, PatientsInquiryRequest params);
 }

--- a/src/main/java/com/dev/patientpractice/repository/querydsl/PatientRepositoryCustom.java
+++ b/src/main/java/com/dev/patientpractice/repository/querydsl/PatientRepositoryCustom.java
@@ -5,5 +5,5 @@ import com.dev.patientpractice.dto.response.patient.PatientsInquiryResponse;
 
 public interface PatientRepositoryCustom {
 
-    PatientsInquiryResponse findAllByConditions(int pageNo, int pageSize, PatientsInquiryRequest params);
+    PatientsInquiryResponse findAllByConditions(PatientsInquiryRequest params);
 }

--- a/src/main/java/com/dev/patientpractice/repository/querydsl/PatientRepositoryCustom.java
+++ b/src/main/java/com/dev/patientpractice/repository/querydsl/PatientRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.dev.patientpractice.repository.querydsl;
+
+import com.dev.patientpractice.dto.request.patient.PatientsInquiryRequest;
+import com.dev.patientpractice.dto.response.patient.PatientsInquiryResponse;
+
+import java.util.List;
+
+public interface PatientRepositoryCustom {
+
+    List<PatientsInquiryResponse> findAllByConditions(int pageNo, int pageSize, PatientsInquiryRequest params);
+}

--- a/src/main/java/com/dev/patientpractice/repository/querydsl/PatientRepositoryImpl.java
+++ b/src/main/java/com/dev/patientpractice/repository/querydsl/PatientRepositoryImpl.java
@@ -53,6 +53,7 @@ public class PatientRepositoryImpl implements PatientRepositoryCustom {
                         visit.receivedAt.max().as("latestVisit")))
                 .from(patient)
                 .leftJoin(patient.visits, visit)
+                .on(visit.visitStatusCode.in("1", "2"))
                 .where(builder)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())

--- a/src/main/java/com/dev/patientpractice/repository/querydsl/PatientRepositoryImpl.java
+++ b/src/main/java/com/dev/patientpractice/repository/querydsl/PatientRepositoryImpl.java
@@ -1,0 +1,76 @@
+package com.dev.patientpractice.repository.querydsl;
+
+import com.dev.patientpractice.dto.request.patient.PatientsInquiryRequest;
+import com.dev.patientpractice.dto.response.patient.PatientsInquiryResponse;
+import com.dev.patientpractice.exception.ErrorCode;
+import com.dev.patientpractice.exception.PatientApplicationException;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.dev.patientpractice.entity.QPatient.patient;
+import static com.dev.patientpractice.entity.QVisit.visit;
+
+@Repository
+@RequiredArgsConstructor
+public class PatientRepositoryImpl implements PatientRepositoryCustom {
+
+    private final JPAQueryFactory factory;
+
+    @Override
+    public List<PatientsInquiryResponse> findAllByConditions(int pageNo, int pageSize, PatientsInquiryRequest params) {
+        Pageable pageable = PageRequest.of(pageNo - 1, pageSize);
+        BooleanBuilder builder = setBuilder(params);
+
+        List<PatientsInquiryResponse> results = factory
+                .select(Projections.constructor(PatientsInquiryResponse.class,
+                        patient.name.as("name"),
+                        patient.registrationNumber.as("registrationNumber"),
+                        patient.genderCode.as("genderCode"),
+                        patient.birthDate.as("birthDate"),
+                        patient.phoneNumber.as("phoneNumber"),
+                        visit.receivedAt.max().as("latestVisit")))
+                .from(patient)
+                .leftJoin(patient.visits, visit)
+                .where(builder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(patient.id.desc())
+                .groupBy(patient.id)
+                .fetch();
+
+        // TODO 페이지관련 데이터 처리
+
+        if (results.isEmpty()) {
+            throw new PatientApplicationException(ErrorCode.PATIENT_NOT_FOUND);
+        }
+
+        return results;
+    }
+
+    public BooleanBuilder setBuilder(PatientsInquiryRequest params) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (StringUtils.hasText(params.getName())) {
+            builder.and(patient.name.eq(params.getName()));
+        }
+
+        if (Objects.nonNull(params.getBirthDate())) {
+            builder.and(patient.birthDate.eq(params.getBirthDate().toString()));
+        }
+
+        if (StringUtils.hasText(params.getRegistrationNumber())) {
+            builder.and(patient.registrationNumber.eq(params.getRegistrationNumber()));
+        }
+
+        return builder;
+    }
+}

--- a/src/main/java/com/dev/patientpractice/repository/querydsl/PatientRepositoryImpl.java
+++ b/src/main/java/com/dev/patientpractice/repository/querydsl/PatientRepositoryImpl.java
@@ -25,11 +25,11 @@ public class PatientRepositoryImpl implements PatientRepositoryCustom {
     private final JPAQueryFactory factory;
 
     @Override
-    public PatientsInquiryResponse findAllByConditions(int pageNo, int pageSize, PatientsInquiryRequest params) {
+    public PatientsInquiryResponse findAllByConditions(PatientsInquiryRequest params) {
         BooleanBuilder builder = setBuilderByConditions(params);
         long totalCount = getTotalCount(builder);
 
-        Pageable pageable = PageRequest.of(pageNo - 1, pageSize);
+        Pageable pageable = PageRequest.of(params.getPageNo() - 1, params.getPageSize());
         List<PatientInquiry> results = findAllByConditions(pageable, builder);
 
         return PatientsInquiryResponse.of(results, pageable, totalCount);
@@ -63,6 +63,8 @@ public class PatientRepositoryImpl implements PatientRepositoryCustom {
 
     public BooleanBuilder setBuilderByConditions(PatientsInquiryRequest params) {
         BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(patient.hospital.id.eq(params.getHospitalId()));
 
         if (StringUtils.hasText(params.getName())) {
             builder.and(patient.name.eq(params.getName()));

--- a/src/main/java/com/dev/patientpractice/service/PatientService.java
+++ b/src/main/java/com/dev/patientpractice/service/PatientService.java
@@ -17,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -76,7 +75,7 @@ public class PatientService {
     }
 
     @Transactional(readOnly = true)
-    public PatientsInquiryResponse getPatients(int pageNo, int pageSize, PatientsInquiryRequest params) {
-        return patientRepository.findAllByConditions(pageNo, pageSize, params);
+    public PatientsInquiryResponse getPatients(PatientsInquiryRequest params) {
+        return patientRepository.findAllByConditions(params);
     }
 }

--- a/src/main/java/com/dev/patientpractice/service/PatientService.java
+++ b/src/main/java/com/dev/patientpractice/service/PatientService.java
@@ -2,7 +2,9 @@ package com.dev.patientpractice.service;
 
 import com.dev.patientpractice.dto.request.patient.PatientModificationRequest;
 import com.dev.patientpractice.dto.request.patient.PatientRegistrationRequest;
+import com.dev.patientpractice.dto.request.patient.PatientsInquiryRequest;
 import com.dev.patientpractice.dto.response.patient.PatientInquiryResponse;
+import com.dev.patientpractice.dto.response.patient.PatientsInquiryResponse;
 import com.dev.patientpractice.entity.Hospital;
 import com.dev.patientpractice.entity.Patient;
 import com.dev.patientpractice.exception.ErrorCode;
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -70,5 +73,10 @@ public class PatientService {
         Patient patient = patientRepository.findByIdAndDeleted(patientId, false)
                 .orElseThrow(() -> new PatientApplicationException(ErrorCode.PATIENT_NOT_FOUND, String.format("환자 ID: %s", patientId)));
         return PatientInquiryResponse.from(patient);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PatientsInquiryResponse> getPatients(int pageNo, int pageSize, PatientsInquiryRequest params) {
+        return patientRepository.findAllByConditions(pageNo, pageSize, params);
     }
 }

--- a/src/main/java/com/dev/patientpractice/service/PatientService.java
+++ b/src/main/java/com/dev/patientpractice/service/PatientService.java
@@ -76,7 +76,7 @@ public class PatientService {
     }
 
     @Transactional(readOnly = true)
-    public List<PatientsInquiryResponse> getPatients(int pageNo, int pageSize, PatientsInquiryRequest params) {
+    public PatientsInquiryResponse getPatients(int pageNo, int pageSize, PatientsInquiryRequest params) {
         return patientRepository.findAllByConditions(pageNo, pageSize, params);
     }
 }


### PR DESCRIPTION
- 각 병원에서의 환자가 조회되게 구현한다.
    - 모든 병원의 환자가 조회되면 안된다.
- 환자가 한 명도 없을 경우에는 빈 배열을 반환한다.
- 환자에대한 페이지 데이터를 반환한다.(현재 페이지, 현재 페이지에서 보여지는 데이터 수, 전체 페이지, 전체 데이터 수)
- 페이지는 1부터 시작하도록 구현한다.
- 환자방문이 존재하지 않을 경우에는 null을 반환하고, 존재할 경우에는 가장 최근의 환자방문 이력을 반환한다.
    - 환자방문은 방문상태코드가 3(취소) 일 경우에는 조회 시 제외한다.
- 환자이름, 환자등록번호, 생년월일에 대한 조건에 맞게 조회한다.
- 환자 조회에 대한 정렬은 환자 ID 역순으로 진행한다.

issue : #27 